### PR TITLE
Fix manifest validation issues

### DIFF
--- a/manifest.xml
+++ b/manifest.xml
@@ -1,12 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<OfficeApp xmlns="http://schemas.microsoft.com/office/appforoffice/1.1" xsi:type="TaskPaneApp" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<OfficeApp xmlns="http://schemas.microsoft.com/office/appforoffice/1.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="TaskPaneApp">
   <Id>7096c774-7d65-4fd6-8e6a-e7afb5c5f3ad</Id>
   <Version>1.0.0.0</Version>
   <ProviderName>Your Company</ProviderName>
   <DefaultLocale>en-US</DefaultLocale>
   <DisplayName DefaultValue="HelloReactAddin"/>
-  <SupportUrl DefaultValue="https://localhost:3000"/>
   <Description DefaultValue="A Hello World React Add-in"/>
+  <IconUrl DefaultValue="https://localhost:3000/icon-32.png"/>
+  <SupportUrl DefaultValue="https://localhost:3000"/>
   <AppDomains>
     <AppDomain>https://localhost:3000</AppDomain>
   </AppDomains>


### PR DESCRIPTION
## Summary
- update Office add-in manifest schema

## Testing
- `npx --yes office-addin-manifest validate manifest.xml` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6846c25a13b48326899d2dac37e776e9