### PR TITLE
Enable HTTPS server for add‑in

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ This project contains a minimal React-based Excel add-in that displays **Hello W
    ```bash
    node server.js
    ```
-   The server hosts the add-in files on `http://localhost:3000`.
+   The server hosts the add-in files on `https://localhost:3000`. If the required
+   certificates do not exist they will be generated automatically.
 
 2. Sideload the add-in in Excel by loading the `manifest.xml` file. See the [Office Add-in sideloading documentation](https://learn.microsoft.com/office/dev/add-ins/testing/create-a-network-shared-folder-catalog-for-task-pane-and-content-add-ins) for details.
 

--- a/server.js
+++ b/server.js
@@ -1,10 +1,31 @@
-const http = require('http');
+const https = require('https');
 const fs = require('fs');
 const path = require('path');
+const os = require('os');
+const { execSync } = require('child_process');
 
 const port = 3000;
 
-const server = http.createServer((req, res) => {
+const certDir = path.join(os.homedir(), '.office-addin-dev-certs');
+const keyPath = path.join(certDir, 'localhost.key');
+const certPath = path.join(certDir, 'localhost.crt');
+
+if (!fs.existsSync(keyPath) || !fs.existsSync(certPath)) {
+  console.log('Certificates not found. Generating new ones...');
+  try {
+    execSync('npx office-addin-dev-certs install', { stdio: 'inherit' });
+  } catch (err) {
+    console.error('Failed to generate certificates:', err);
+    process.exit(1);
+  }
+}
+
+const options = {
+  key: fs.readFileSync(keyPath),
+  cert: fs.readFileSync(certPath),
+};
+
+const server = https.createServer(options, (req, res) => {
   let filePath = '.' + req.url;
   if (filePath === './') {
     filePath = './taskpane.html';
@@ -29,5 +50,5 @@ const server = http.createServer((req, res) => {
 });
 
 server.listen(port, () => {
-  console.log(`Server running at http://localhost:${port}`);
+  console.log(`Server running at https://localhost:${port}`);
 });


### PR DESCRIPTION
## Summary
- serve the add-in using HTTPS with dev certificates
- document automatic certificate generation
- generate certificates at startup if missing

## Testing
- `npm test`
- `npm start` *(fails: E403 when downloading office-addin-dev-certs)*

------
https://chatgpt.com/codex/tasks/task_e_6846c3cf36848326bca9170bcded285c