### PR TITLE
Add HWA ribbon with dialog

### DIFF
--- a/manifest.xml
+++ b/manifest.xml
@@ -56,6 +56,18 @@
                 </Control>
               </Group>
             </OfficeTab>
+            <CustomTab id="TabHWA">
+              <Label resid="TabHWA.Label"/>
+              <Group id="HWAGroup">
+                <Label resid="HWAGroup.Label"/>
+                <Control xsi:type="Button" id="DialogButton">
+                  <Label resid="DialogButton.Label"/>
+                  <Action xsi:type="ExecuteFunction">
+                    <FunctionName>openDialog</FunctionName>
+                  </Action>
+                </Control>
+              </Group>
+            </CustomTab>
           </ExtensionPoint>
         </DesktopFormFactor>
       </Host>
@@ -75,6 +87,9 @@
         <bt:String id="GetStarted.Title" DefaultValue="Get started with your sample add-in!"/>
         <bt:String id="CommandsGroup.Label" DefaultValue="Commands Group"/>
         <bt:String id="TaskpaneButton.Label" DefaultValue="Show Task Pane"/>
+        <bt:String id="TabHWA.Label" DefaultValue="HWA"/>
+        <bt:String id="HWAGroup.Label" DefaultValue="HWA"/>
+        <bt:String id="DialogButton.Label" DefaultValue="Open Dialog"/>
       </bt:ShortStrings>
       <bt:LongStrings>
         <bt:String id="GetStarted.Description" DefaultValue="Your sample add-in loaded successfully. Go to the HOME tab and click the 'Show Task Pane' button to get started."/>

--- a/src/commands/commands.ts
+++ b/src/commands/commands.ts
@@ -33,3 +33,15 @@ function action(event: Office.AddinCommands.Event) {
 
 // Register the function with Office.
 Office.actions.associate("action", action);
+
+async function openDialog(event: Office.AddinCommands.Event) {
+  Office.context.ui.displayDialogAsync(
+    "https://localhost:3000/dialog.html",
+    { height: 40, width: 30 },
+    () => {
+      event.completed();
+    }
+  );
+}
+
+Office.actions.associate("openDialog", openDialog);

--- a/src/dialog/dialog.html
+++ b/src/dialog/dialog.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <title>Dialog</title>
+  </head>
+  <body>
+    <h1>Hello world from dialog</h1>
+  </body>
+</html>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -71,6 +71,10 @@ module.exports = async (env, options) => {
             to: "assets/[name][ext][query]",
           },
           {
+            from: "src/dialog/dialog.html",
+            to: "dialog.html",
+          },
+          {
             from: "manifest*.xml",
             to: "[name][ext]",
             transform(content) {


### PR DESCRIPTION
## Summary
- add a simple dialog page
- enable copying dialog.html through webpack
- wire an `openDialog` command that launches the dialog
- expose a new `HWA` tab in the manifest containing a button

## Testing
- `npx webpack --mode production` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6846cde9eb388326893a434efbd381cb